### PR TITLE
Fix builder shorthand from 'br' to 'b' to avoid pflag panic

### DIFF
--- a/.github/workflows/generate-linter-advanced.yml
+++ b/.github/workflows/generate-linter-advanced.yml
@@ -37,7 +37,7 @@ jobs:
         run: echo "PROJECT_DIRECTORY=${{ matrix.framework }}" | sed 's/\//-/g' >> $GITHUB_ENV
 
       - name: build templates
-        run: script -q /dev/null -c "go run main.go create -n ${{ env.PROJECT_DIRECTORY }} -f ${{ matrix.framework}} -d ${{ matrix.driver }} -g ${{ matrix.git}} -br ${{ matrix.builder}} --advanced --feature ${{ matrix.advanced }}"
+        run: script -q /dev/null -c "go run main.go create -n ${{ env.PROJECT_DIRECTORY }} -f ${{ matrix.framework}} -d ${{ matrix.driver }} -g ${{ matrix.git}} -b ${{ matrix.builder}} --advanced --feature ${{ matrix.advanced }}"
 
       - if: ${{ matrix.advanced == 'htmx' || matrix.advanced == 'tailwind' }}
         name: Install Templ & gen templates

--- a/.github/workflows/generate-linter-core.yml
+++ b/.github/workflows/generate-linter-core.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo "PROJECT_DIRECTORY=${{ matrix.framework }}" | sed 's/\//-/g' >> $GITHUB_ENV
 
       - name: build templates
-        run: script -q /dev/null -c "go run main.go create -n ${{ env.PROJECT_DIRECTORY }} -f ${{ matrix.framework}} -d ${{ matrix.driver }} -g ${{ matrix.git}} -br ${{ matrix.builder}}"
+        run: script -q /dev/null -c "go run main.go create -n ${{ env.PROJECT_DIRECTORY }} -f ${{ matrix.framework}} -d ${{ matrix.driver }} -g ${{ matrix.git}} -b ${{ matrix.builder}}"
 
       - name: golangci-lint
         run: |

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -53,7 +53,7 @@ func init() {
 	createCmd.Flags().BoolP("advanced", "a", false, "Get prompts for advanced features")
 	createCmd.Flags().Var(&advancedFeatures, "feature", fmt.Sprintf("Advanced feature to use. Allowed values: %s", strings.Join(flags.AllowedAdvancedFeatures, ", ")))
 	createCmd.Flags().VarP(&flagGit, "git", "g", fmt.Sprintf("Git to use. Allowed values: %s", strings.Join(flags.AllowedGitsOptions, ", ")))
-	createCmd.Flags().VarP(&flagBuilder, "builder", "br", fmt.Sprintf("Builder to use. Allowed values: %s", strings.Join(flags.AllowedBuilders, ", ")))
+	createCmd.Flags().VarP(&flagBuilder, "builder", "b", fmt.Sprintf("Builder to use. Allowed values: %s", strings.Join(flags.AllowedBuilders, ", ")))
 
 	utils.RegisterStaticCompletions(createCmd, "framework", flags.AllowedProjectTypes)
 	utils.RegisterStaticCompletions(createCmd, "driver", flags.AllowedDBDrivers)
@@ -110,7 +110,7 @@ var createCmd = &cobra.Command{
 			Advanced: &multiSelect.Selection{
 				Choices: make(map[string]bool),
 			},
-			Git: &multiInput.Selection{},
+			Git:     &multiInput.Selection{},
 			Builder: &multiInput.Selection{},
 		}
 
@@ -120,10 +120,10 @@ var createCmd = &cobra.Command{
 			DBDriver:        flagDBDriver,
 			FrameworkMap:    make(map[flags.Framework]program.Framework),
 			DBDriverMap:     make(map[flags.Database]program.Driver),
-			BuilderMap:     make(map[flags.Builder]program.Builder),
+			BuilderMap:      make(map[flags.Builder]program.Builder),
 			AdvancedOptions: make(map[string]bool),
 			GitOptions:      flagGit,
-			Builder:	 flagBuilder,
+			Builder:         flagBuilder,
 		}
 
 		steps := steps.InitSteps(flagFramework, flagDBDriver)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

The current shorthand for the `--builder` flag was incorrectly set to "br", which is invalid in pflag as it only supports single-character shorthands. This caused the program to panic at runtime and workflows using `-br` to fail.

## Description of Changes: 

- Changed shorthand of the `--builder` flag from `"br"` to `"b"` in the code.
- Updated all GitHub workflows that used the `-br` shorthand to use the correct `-b` shorthand.
- Verified no other shorthands use invalid multi-character shortcuts.

## Checklist

- [x] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (check issue ticket #218)
